### PR TITLE
update 优化 `scopeDialog` 兼容性

### DIFF
--- a/net/src/main/java/com/drake/net/interfaces/NetDialogFactory.kt
+++ b/net/src/main/java/com/drake/net/interfaces/NetDialogFactory.kt
@@ -2,7 +2,7 @@ package com.drake.net.interfaces
 
 import android.app.Dialog
 import android.app.ProgressDialog
-import androidx.fragment.app.FragmentActivity
+import androidx.activity.ComponentActivity
 import com.drake.net.R
 
 fun interface NetDialogFactory {
@@ -10,12 +10,12 @@ fun interface NetDialogFactory {
     /**
      * 构建并返回Dialog. 当使用 scopeDialog 作用域时将会自动显示该对话框且作用域完成后关闭对话框
      *
-     * @param activity 请求发生所在的[FragmentActivity]
+     * @param activity 请求发生所在的[ComponentActivity]
      */
-    fun onCreate(activity: FragmentActivity): Dialog
+    fun onCreate(activity: ComponentActivity): Dialog
 
     companion object DEFAULT : NetDialogFactory {
-        override fun onCreate(activity: FragmentActivity): Dialog {
+        override fun onCreate(activity: ComponentActivity): Dialog {
             val progress = ProgressDialog(activity)
             progress.setMessage(activity.getString(R.string.net_dialog_msg))
             return progress

--- a/net/src/main/java/com/drake/net/scope/DialogCoroutineScope.kt
+++ b/net/src/main/java/com/drake/net/scope/DialogCoroutineScope.kt
@@ -17,7 +17,7 @@
 package com.drake.net.scope
 
 import android.app.Dialog
-import androidx.fragment.app.FragmentActivity
+import androidx.activity.ComponentActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.OnLifecycleEvent
@@ -33,13 +33,12 @@ import kotlinx.coroutines.Dispatchers
  * 错误: 提示错误信息, 关闭对话框
  * 完全: 关闭对话框
  *
- * @param activity 对话框跟随生命周期的FragmentActivity
+ * @param activity 对话框跟随生命周期的ComponentActivity
  * @param dialog 不使用默认的加载对话框而指定对话框
  * @param cancelable 是否允许用户取消对话框
  */
-@Suppress("DEPRECATION")
 class DialogCoroutineScope(
-    val activity: FragmentActivity,
+    val activity: ComponentActivity,
     var dialog: Dialog? = null,
     val cancelable: Boolean = true,
     dispatcher: CoroutineDispatcher = Dispatchers.Main

--- a/net/src/main/java/com/drake/net/utils/Scope.kt
+++ b/net/src/main/java/com/drake/net/utils/Scope.kt
@@ -18,6 +18,7 @@ package com.drake.net.utils
 
 import android.app.Dialog
 import android.view.View
+import androidx.activity.ComponentActivity
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Lifecycle
@@ -88,7 +89,7 @@ fun Fragment.scopeLife(
  * @param cancelable 对话框是否可取消
  * @param dispatcher 调度器, 默认运行在[Dispatchers.Main]即主线程下
  */
-fun FragmentActivity.scopeDialog(
+fun ComponentActivity.scopeDialog(
     dialog: Dialog? = null,
     cancelable: Boolean = true,
     dispatcher: CoroutineDispatcher = Dispatchers.Main,


### PR DESCRIPTION
`androidx.activity.ComponentActivity` 上已支持生命周期管理，所以创建`scopeDialog`时不一定必须使用`FragmentActivity`。

优化后的好处:
目前只发现了纯`Compose`项目，默认不`implementation "androidx.appcompat:appcompat:x.x.x"`，且默认Activity是继承于`androidx.activity.ComponentActivity`，`setContent{ }`也是基于`androidx.activity.ComponentActivity`扩展。所以也算是对`Compose`的兼容吧。

> 虽然Compsoe也可以引入appcompat来兼容这个问题，但是纯Compose项目似乎不需要appcompat.

*Compose setContent 扩展截取*
```kotlin
import androidx.activity.ComponentActivity
...

public fun ComponentActivity.setContent(
    parent: CompositionContext? = null,
    content: @Composable () -> Unit
) {
    val existingComposeView = window.decorView
        .findViewById<ViewGroup>(android.R.id.content)
        .getChildAt(0) as? ComposeView
...
```